### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A commitment is a datatype designated by a *name
 A belief is a datatype designated by a #name
 
 ```clojure
-#sunny
+# sunny
 ```
 
 ### Convincing


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
